### PR TITLE
Rustup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,9 +1,9 @@
 [[package]]
 name = "aho-corasick"
-version = "0.6.6"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -19,9 +19,30 @@ name = "atty"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "backtrace"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "backtrace-sys 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-demangle 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "backtrace-sys"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -29,7 +50,7 @@ name = "base64"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "byteorder 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "safemem 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -38,17 +59,17 @@ name = "base64"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "byteorder 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "safemem 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "base64"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "byteorder 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "safemem 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "safemem 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -56,28 +77,28 @@ name = "bincode"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "byteorder 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "bitflags"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "byteorder"
-version = "1.2.4"
+version = "1.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cc"
-version = "1.0.18"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cfg-if"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -87,11 +108,11 @@ source = "git+https://github.com/oli-obk/cgraph.git?rev=b65e460ee323b31dca55b554
 
 [[package]]
 name = "chrono"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -121,9 +142,9 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "cfg-if 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-utils 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "nodrop 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -134,32 +155,47 @@ name = "crossbeam-utils"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cfg-if 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "dtoa"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "env_logger"
-version = "0.5.11"
+version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "humantime 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "termcolor 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "termcolor 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "failure"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "backtrace 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure_derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "failure_derive"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.14.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "synstructure 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "flate2"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "miniz-sys 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -170,7 +206,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "gcc"
-version = "0.3.54"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -180,7 +216,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "httparse"
-version = "1.3.2"
+version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -197,7 +233,7 @@ version = "0.10.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "base64 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "httparse 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "httparse 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -214,24 +250,25 @@ name = "idna"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "matches 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-normalization 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "isatty"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "itoa"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -246,12 +283,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "lazy_static"
-version = "1.0.2"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "libc"
-version = "0.2.42"
+version = "0.2.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -264,28 +304,30 @@ name = "log"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "log"
-version = "0.4.3"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cfg-if 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "matches"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "memchr"
-version = "2.0.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -306,20 +348,19 @@ name = "miniz-sys"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "miri"
 version = "0.1.0"
-source = "git+https://github.com/solson/miri.git#e0526863ed6f5b7e4c63e032a37dfc17f8c6ca26"
+source = "git+https://github.com/solson/miri.git#8b14b03368429e6ee2a8ac0e0c876505606ab1f1"
 dependencies = [
- "byteorder 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "env_logger 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vergen 3.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -332,12 +373,12 @@ name = "num-integer"
 version = "0.1.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num-traits 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "num-traits"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -345,7 +386,7 @@ name = "num_cpus"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -353,26 +394,29 @@ name = "onig"
 version = "3.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
- "onig_sys 68.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "onig_sys 68.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "onig_sys"
-version = "68.2.0"
+version = "68.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
- "pkg-config 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "open"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "ordermap"
@@ -381,15 +425,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "pear"
-version = "0.0.19"
+version = "0.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "pear_codegen"
-version = "0.0.19"
+version = "0.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "version_check 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "yansi 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -400,7 +444,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.12"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -409,9 +453,9 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "base64 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "byteorder 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "chrono 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)",
  "xml-rs 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -420,34 +464,26 @@ name = "priroda"
 version = "0.1.0"
 dependencies = [
  "cgraph 0.1.0 (git+https://github.com/oli-obk/cgraph.git?rev=b65e460ee323b31dca55b5541141a6b73272e72a)",
- "env_logger 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "horrorshow 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "miri 0.1.0 (git+https://github.com/solson/miri.git)",
- "open 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "open 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "promising-future 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rental 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rocket 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "rocket_codegen 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rental 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rocket 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rocket_codegen 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "syntect 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "proc-macro2"
-version = "0.4.9"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -468,18 +504,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "quote"
-version = "0.5.2"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "quote"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "proc-macro2 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -496,8 +524,8 @@ version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "crossbeam-deque 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -516,14 +544,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.0.2"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "aho-corasick 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aho-corasick 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex-syntax 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "utf8-ranges 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -541,21 +569,21 @@ dependencies = [
 
 [[package]]
 name = "rental"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rental-impl 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rental-impl 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rental-impl"
-version = "0.5.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.13.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -563,47 +591,57 @@ name = "ring"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gcc 0.3.55 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "untrusted 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rocket"
-version = "0.3.15"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "base64 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "cookie 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.10.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "isatty 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "isatty 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ordermap 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "pear 0.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "pear_codegen 0.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "smallvec 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pear 0.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pear_codegen 0.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "state 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "toml 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "version_check 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "yansi 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rocket_codegen"
-version = "0.3.15"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "rocket 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "version_check 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rocket 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "yansi 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "ryu"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "safemem"
@@ -611,11 +649,16 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "safemem"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "same-file"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -625,32 +668,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde"
-version = "1.0.70"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde_derive"
-version = "1.0.70"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.14.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.24"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "dtoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "itoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ryu 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "smallvec"
-version = "0.6.3"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -668,21 +711,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "syn"
-version = "0.13.11"
+version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "syn"
-version = "0.14.5"
+version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.14.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -692,26 +746,26 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bincode 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "flate2 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "flate2 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "onig 3.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "plist 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex-syntax 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "walkdir 2.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "yaml-rust 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "walkdir 2.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "yaml-rust 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "termcolor"
-version = "1.0.1"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "wincolor 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wincolor 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -719,18 +773,17 @@ name = "termion"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "thread_local"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lazy_static 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -746,17 +799,17 @@ name = "time"
 version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "toml"
-version = "0.4.6"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -779,7 +832,7 @@ name = "unicase"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "version_check 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -787,7 +840,7 @@ name = "unicode-bidi"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "matches 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -819,18 +872,28 @@ version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "matches 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "utf8-ranges"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "vergen"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "version_check"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -840,16 +903,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "walkdir"
-version = "2.1.4"
+version = "2.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "same-file 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "same-file 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "winapi"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -862,16 +926,25 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "winapi-util"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "wincolor"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -879,12 +952,12 @@ name = "xml-rs"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "yaml-rust"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "linked-hash-map 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -896,97 +969,102 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
-"checksum aho-corasick 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c1c6d463cbe7ed28720b5b489e7c083eeb8f90d08be2a0d6bb9e1ffea9ce1afa"
+"checksum aho-corasick 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)" = "68f56c7353e5a9547cbd76ed90f7bb5ffc3ba09d4ea9bd1d8c06c8b1142eeb5a"
 "checksum arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)" = "a1e964f9e24d588183fcb43503abda40d288c8657dfc27311516ce2f05675aef"
 "checksum atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652"
+"checksum backtrace 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "89a47830402e9981c5c41223151efcced65a0510c13097c769cede7efb34782a"
+"checksum backtrace-sys 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)" = "c66d56ac8dabd07f6aacdaf633f4b8262f5b3601a810a0dcddffd5c22c69daa0"
 "checksum base64 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "96434f987501f0ed4eb336a411e0631ecd1afa11574fe148587adc4ff96143c9"
 "checksum base64 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7c4a342b450b268e1be8036311e2c613d7f8a7ed31214dff1cc3b60852a3168d"
-"checksum base64 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "85415d2594767338a74a30c1d370b2f3262ec1b4ed2d7bba5b3faf4de40467d9"
+"checksum base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "489d6c0ed21b11d038c31b6ceccca973e65d73ba3bd8ecb9a2babf5546164643"
 "checksum bincode 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9f2fb9e29e72fd6bc12071533d5dc7664cb01480c59406f656d7ac25c7bd8ff7"
-"checksum bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d0c54bb8f454c567f21197eefcdbf5679d0bd99f2ddbe52e84c77061952e6789"
-"checksum byteorder 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8389c509ec62b9fe8eca58c502a0acaf017737355615243496cde4994f8fa4f9"
-"checksum cc 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)" = "2119ea4867bd2b8ed3aecab467709720b2d55b1bcfe09f772fd68066eaf15275"
-"checksum cfg-if 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "efe5c877e17a9c717a0bf3613b2709f723202c4e4675cc8f12926ded29bcb17e"
+"checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
+"checksum byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "90492c5858dd7d2e78691cfb89f90d273a2800fc11d98f60786e5d87e2f83781"
+"checksum cc 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)" = "f159dfd43363c4d08055a07703eb7a3406b0dac4d0584d96965a3262db3c9d16"
+"checksum cfg-if 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0c4e7bb64a8ebb0d856483e1e682ea3422f883c5f5615a90d51a2c82fe87fdd3"
 "checksum cgraph 0.1.0 (git+https://github.com/oli-obk/cgraph.git?rev=b65e460ee323b31dca55b5541141a6b73272e72a)" = "<none>"
-"checksum chrono 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e48d85528df61dc964aa43c5f6ca681a19cfa74939b2348d204bd08a981f2fb0"
+"checksum chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "45912881121cb26fad7c38c17ba7daa18764771836b34fab7d3fbd93ed633878"
 "checksum cookie 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "477eb650753e319be2ae77ec368a58c638f9f0c4d941c39bad95e950fb1d1d0d"
 "checksum crossbeam-deque 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f739f8c5363aca78cfb059edf753d8f0d36908c348f3d8d1503f03d8b75d9cf3"
 "checksum crossbeam-epoch 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "927121f5407de9956180ff5e936fe3cf4324279280001cd56b669d28ee7e9150"
 "checksum crossbeam-utils 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2760899e32a1d58d5abb31129f8fae5de75220bc2176e77ff7c627ae45c918d9"
-"checksum dtoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6d301140eb411af13d3115f9a562c85cc6b541ade9dfa314132244aaee7489dd"
-"checksum env_logger 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)" = "7873e292d20e8778f951278972596b3df36ac72a65c5b406f6d4961070a870c1"
-"checksum flate2 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "37847f133aae7acf82bb9577ccd8bda241df836787642654286e79679826a54b"
+"checksum env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)" = "15b0a4d2e39f8420210be8b27eeda28029729e2fd4291019455016c348240c38"
+"checksum failure 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7efb22686e4a466b1ec1a15c2898f91fa9cb340452496dca654032de20ff95b9"
+"checksum failure_derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "946d0e98a50d9831f5d589038d2ca7f8f455b1c21028c0db0e84116a12696426"
+"checksum flate2 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4af030962d89d62aa52cd9492083b1cd9b2d1a77764878102a6c0f86b4d5444d"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
-"checksum gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)" = "5e33ec290da0d127825013597dbdfc28bee4964690c7ce1166cbc2a7bd08b1bb"
+"checksum gcc 0.3.55 (registry+https://github.com/rust-lang/crates.io-index)" = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
 "checksum horrorshow 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "99f5260b3afa2089a0c185c1948dfea63075ca0c2e37d3b151fa1968aa5f6faf"
-"checksum httparse 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7b6288d7db100340ca12873fd4d08ad1b8f206a9457798dfb17c018a33fee540"
+"checksum httparse 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e8734b0cfd3bc3e101ec59100e101c2eecd19282202e87808b3037b442777a83"
 "checksum humantime 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0484fda3e7007f2a4a0d9c3a703ca38c71c54c55602ce4660c419fd32e188c9e"
 "checksum hyper 0.10.13 (registry+https://github.com/rust-lang/crates.io-index)" = "368cb56b2740ebf4230520e2b90ebb0461e69034d85d1945febd9b3971426db2"
 "checksum idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
-"checksum isatty 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "6c324313540cd4d7ba008d43dc6606a32a5579f13cc17b2804c13096f0a5c522"
-"checksum itoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5adb58558dcd1d786b5f0bd15f3226ee23486e24b7b58304b60f64dc68e62606"
+"checksum isatty 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e31a8281fc93ec9693494da65fbf28c0c2aa60a2eaec25dc58e2f31952e95edc"
+"checksum itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1306f3464951f30e30d12373d31c79fbd52d236e5e896fd92f96ec7babbbe60b"
 "checksum language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
 "checksum lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
-"checksum lazy_static 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "fb497c35d362b6a331cfd94956a07fc2c78a4604cdbee844a81170386b996dd3"
-"checksum libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)" = "b685088df2b950fccadf07a7187c8ef846a959c142338a48f9dc0b94517eb5f1"
+"checksum lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ca488b89a5657b0a2ecd45b95609b3e848cf1755da332a0da46e2b2b1cb371a7"
+"checksum libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)" = "76e3a3ef172f1a0b9a9ff0dd1491ae5e6c948b94479a3021819ba7d860c8645d"
 "checksum linked-hash-map 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "70fb39025bc7cdd76305867c4eccf2f2dcf6e9a57f5b21a93e1c2d86cd03ec9e"
 "checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
-"checksum log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "61bd98ae7f7b754bc53dca7d44b604f733c6bba044ea6f41bc8d89272d8161d2"
-"checksum matches 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "835511bab37c34c47da5cb44844bea2cfde0236db0b506f90ea4224482c9774a"
-"checksum memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "796fba70e76612589ed2ce7f45282f5af869e0fdd7cc6199fa1aa1f1d591ba9d"
+"checksum log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "d4fcce5fa49cc693c312001daf1d13411c4a5283796bac1084299ea3e567113f"
+"checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
+"checksum memchr 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4b3629fe9fdbff6daa6c33b90f7c08355c1aca05a3d01fa8063b822fcf185f3b"
 "checksum memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0f9dc261e2b62d7a622bf416ea3c5245cdd5d9a7fcc428c0d06804dfce1775b3"
 "checksum mime 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ba626b8a6de5da682e1caa06bdb42a335aee5a84db8e5046a3e8ab17ba0a3ae0"
 "checksum miniz-sys 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "609ce024854aeb19a0ef7567d348aaa5a746b32fb72e336df7fcc16869d7e2b4"
 "checksum miri 0.1.0 (git+https://github.com/solson/miri.git)" = "<none>"
 "checksum nodrop 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "9a2228dca57108069a5262f2ed8bd2e82496d2e074a06d1ccc7ce1687b6ae0a2"
 "checksum num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "e83d528d2677f0518c570baf2b7abdcf0cd2d248860b68507bdcb3e91d4c0cea"
-"checksum num-traits 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "630de1ef5cc79d0cdd78b7e33b81f083cbfe90de0f4b2b2f07f905867c70e9fe"
+"checksum num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0b3a5d7cc97d6d30d8b9bc8fa19bf45349ffe46241e8816f50f62f6d6aaabee1"
 "checksum num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c51a3322e4bca9d212ad9a158a02abc6934d005490c054a2778df73a70aa0a30"
 "checksum onig 3.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f5eeb268a4620c74ea5768c6d2ccd492d60a47a8754666b91a46bfc35cd4d1ba"
-"checksum onig_sys 68.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "48b1fc88a091cf46a8ec67a3cd3ffd55f75d3bed741c76f253d78746ec43602b"
-"checksum open 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c281318d992e4432cfa799969467003d05921582a7489a8325e37f8a450d5113"
+"checksum onig_sys 68.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "195ebddbb56740be48042ca117b8fb6e0d99fe392191a9362d82f5f69e510379"
+"checksum open 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "eedfa0ca7b54d84d948bfd058b8f82e767d11f362dd78c36866fd1f69c175867"
 "checksum ordermap 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "b81cf3b8cb96aa0e73bbedfcdc9708d09fec2854ba8d474be4e6f666d7379e8b"
-"checksum pear 0.0.19 (registry+https://github.com/rust-lang/crates.io-index)" = "7fc18e7bc730525f5bcc1069487631a94e5d7389c7f7e63c081cda5c3542ea3e"
-"checksum pear_codegen 0.0.19 (registry+https://github.com/rust-lang/crates.io-index)" = "ac78ce520b1274885d8415a02ae3f1bb06038e0f6862f105aa97060c6a10fd99"
+"checksum pear 0.0.20 (registry+https://github.com/rust-lang/crates.io-index)" = "353fe88ff7a430c0f39ca4ec19e1f8fa0062f696370e8df3080ac40139a63301"
+"checksum pear_codegen 0.0.20 (registry+https://github.com/rust-lang/crates.io-index)" = "fd0f3ef1db2d855e0c00fad8e5a8216a70df6d9c1c7f7a7ac9f1cf50675142b7"
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
-"checksum pkg-config 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)" = "6a52e4dbc8354505ee07e484ab07127e06d87ca6fa7f0a516a2b294e5ad5ad16"
+"checksum pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "676e8eb2b1b4c9043511a9b7bea0915320d7e502b0a079fb03f9635a5252b18c"
 "checksum plist 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "c61ac2afed2856590ae79d6f358a24b85ece246d2aa134741a66d589519b7503"
-"checksum proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "1b06e2f335f48d24442b35a19df506a835fb3547bc3c06ef27340da9acf5cae7"
-"checksum proc-macro2 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)" = "cccdc7557a98fe98453030f077df7f3a042052fae465bb61d2c2c41435cfd9b6"
+"checksum proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)" = "3d7b7eaaa90b4a90a932a9ea6666c95a389e424eff347f0f793979289429feee"
 "checksum promising-future 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "44ba461c1b8785e502867026d893fa52801faccfbfe59efdae7da4b9094b4ce2"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
-"checksum quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9949cfe66888ffe1d53e6ec9d9f3b70714083854be20fd5e271b232a017401e8"
-"checksum quote 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b71f9f575d55555aa9c06188be9d4e2bfc83ed02537948ac0d520c24d0419f1a"
+"checksum quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)" = "dd636425967c33af890042c483632d33fa7a18f19ad1d7ea72e8998c6ef8dea5"
 "checksum rayon 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a77c51c07654ddd93f6cb543c7a849863b03abc7e82591afda6dc8ad4ac3ac4a"
 "checksum rayon-core 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b055d1e92aba6877574d8fe604a63c8b5df60f60e5982bf7ccbb1338ea527356"
 "checksum redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "c214e91d3ecf43e9a4e41e578973adeb14b474f2bee858742d127af75a0112b1"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
-"checksum regex 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5bbbea44c5490a1e84357ff28b7d518b4619a159fed5d25f6c1de2d19cc42814"
+"checksum regex 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "2069749032ea3ec200ca51e4a31df41759190a88edca0d2d86ee8bedf7073341"
 "checksum regex-syntax 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8e931c58b93d86f080c734bfd2bce7dd0079ae2331235818133c8be7f422e20e"
 "checksum regex-syntax 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "747ba3b235651f6e2f67dfa8bcdcd073ddb7c243cb21c442fc12395dfcac212d"
-"checksum rental 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c41f0b3b22eb38038b317456517ff80ae77a7232bd166034fba9c85fa1c0982e"
-"checksum rental-impl 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5a650ece3255e5ce7bf69eec8e65d7171e9627491cea8b72a709e67de59a419c"
+"checksum rental 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ca24bf9b98e3df0bb359f1bbb8ef993a0093d8432500c5eaf3ae724f30b5f754"
+"checksum rental-impl 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a269533a9b93bbaa4848260e51b64564cc445d46185979f31974ec703374803a"
 "checksum ring 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1f2a6dc7fc06a05e6de183c5b97058582e9da2de0c136eafe49609769c507724"
-"checksum rocket 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "c9010c81b707444fe8de4f83380e6e18bbc2825aac2da797d5553ce3d5b3e702"
-"checksum rocket_codegen 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "0109d1692a1a05c267ed1eef94ff018bd360e0b6487c8678da4ebbbdbf02cef7"
+"checksum rocket 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)" = "a61d746c68f1d357f6e011985570474c4af368aa81900320074098d34ed0c64e"
+"checksum rocket_codegen 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)" = "7873d65adfa3e440ac373a28240341853da170913aad7e4207c0198389e5d0e9"
+"checksum rustc-demangle 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "bcfe5b13211b4d78e5c2cadfebd7769197d95c639c35a50057eb4c05de811395"
+"checksum ryu 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7153dd96dade874ab973e098cb62fcdbb89a03682e46b144fd09550998d4a4a7"
 "checksum safemem 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e27a8b19b835f7aea908818e871f5cc3a5a186550c30773be987e155e8163d8f"
-"checksum same-file 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "cfb6eded0b06a0b512c8ddbcf04089138c9b4362c2f696f3c3d76039d68f3637"
+"checksum safemem 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8dca453248a96cb0749e36ccdfe2b0b4e54a61bfef89fb97ec621eb8e0a93dd9"
+"checksum same-file 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "10f7794e2fda7f594866840e95f5c5962e886e228e68b6505885811a94dd728c"
 "checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
-"checksum serde 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)" = "0c3adf19c07af6d186d91dae8927b83b0553d07ca56cbf7f2f32560455c91920"
-"checksum serde_derive 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)" = "3525a779832b08693031b8ecfb0de81cd71cfd3812088fafe9a7496789572124"
-"checksum serde_json 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)" = "c3c6908c7b925cd6c590358a4034de93dbddb20c45e1d021931459fd419bf0e2"
-"checksum smallvec 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "26df3bb03ca5eac2e64192b723d51f56c1b1e0860e7c766281f4598f181acdc8"
+"checksum serde 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)" = "84257ccd054dc351472528c8587b4de2dbf0dc0fe2e634030c1a90bfdacebaa9"
+"checksum serde_derive 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)" = "31569d901045afbff7a9479f793177fe9259819aff10ab4f89ef69bbc5f567fe"
+"checksum serde_json 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)" = "43344e7ce05d0d8280c5940cabb4964bea626aa58b1ec0e8c73fa2a8512a38ce"
+"checksum smallvec 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "153ffa32fd170e9944f7e0838edf824a754ec4c1fc64746fcc9fe1f8fa602e5d"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 "checksum state 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7345c971d1ef21ffdbd103a75990a15eb03604fc8b8852ca8cb418ee1a099028"
-"checksum syn 0.13.11 (registry+https://github.com/rust-lang/crates.io-index)" = "14f9bf6292f3a61d2c716723fdb789a41bbe104168e6f496dc6497e531ea1b9b"
-"checksum syn 0.14.5 (registry+https://github.com/rust-lang/crates.io-index)" = "4bad7abdf6633f07c7046b90484f1d9dc055eca39f8c991177b1046ce61dba9a"
+"checksum syn 0.14.9 (registry+https://github.com/rust-lang/crates.io-index)" = "261ae9ecaa397c42b960649561949d69311f08eeaea86a65696e6e46517cf741"
+"checksum syn 0.15.11 (registry+https://github.com/rust-lang/crates.io-index)" = "b036b7b35e846707c0e55c2c9441fa47867c0f87fca416921db3261b1d8c741a"
+"checksum synstructure 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "85bb9b7550d063ea184027c9b8c20ac167cd36d3e06b3a40bceb9d746dc1a7b7"
 "checksum syntect 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "dc8a6f0db88d4afc340522c20d260411e746b2225b257c6b238a75de9d7cec78"
-"checksum termcolor 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "722426c4a0539da2c4ffd9b419d90ad540b4cff4a053be9069c908d4d07e2836"
+"checksum termcolor 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4096add70612622289f2fdcdbd5086dc81c1e2675e6ae58d6c4f62a16c6d7f2f"
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
-"checksum thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "279ef31c19ededf577bfd12dfae728040a21f635b06a24cd670ff510edd38963"
+"checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 "checksum threadpool 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e2f0c90a5f3459330ac8bc0d2f879c693bb7a2f59689c1083fc4ef83834da865"
 "checksum time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "d825be0eb33fda1a7e68012d51e9c7f451dc1a69391e7fdc197060bb8c56667b"
-"checksum toml 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a0263c6c02c4db6c8f7681f9fd35e90de799ebd4cfdeab77a38f4ff6b3d8c0d9"
+"checksum toml 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "4a2ecc31b0351ea18b3fe11274b8db6e4d82bce861bbb22e6dbed40417902c65"
 "checksum traitobject 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "efd1f82c56340fdf16f2a953d7bda4f8fdffba13d93b00844c25572110b26079"
 "checksum typeable 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1410f6f91f21d1612654e7cc69193b0334f909dcf2c790c4826254fbb86f8887"
 "checksum ucd-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fd2be2d6639d0f8fe6cdda291ad456e23629558d466e2789d2c3e9892bda285d"
@@ -997,14 +1075,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
 "checksum untrusted 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f392d7819dbe58833e26872f5f6f0d68b7bbbe90fc3667e98731c4a15ad9a7ae"
 "checksum url 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2a321979c09843d272956e73700d12c4e7d3d92b2ee112b31548aef0d4efc5a6"
-"checksum utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "662fab6525a98beff2921d7f61a39e7d59e0b425ebc7d0d9e66d316e55124122"
-"checksum version_check 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "7716c242968ee87e5542f8021178248f267f295a5c4803beae8b8b7fd9bc6051"
+"checksum utf8-ranges 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fd70f467df6810094968e2fce0ee1bd0e87157aceb026a8c083bcf5e25b9efe4"
+"checksum vergen 3.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1b9696d96ec5d68984d060af80d7ba0ed4eb533978a0efb05ed4b8465f20d04f"
+"checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
-"checksum walkdir 2.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "63636bd0eb3d00ccb8b9036381b526efac53caf112b7783b730ab3f8e44da369"
-"checksum winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "773ef9dcc5f24b7d850d0ff101e542ff24c3b090a9768e03ff889fdef41f00fd"
+"checksum walkdir 2.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "af464bc7be7b785c7ac72e266a6b67c4c9070155606f51655a650a6686204e35"
+"checksum winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "92c1eb33641e276cfa214a0522acad57be5c56b10cb348b3c5117db75f3ac4b0"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+"checksum winapi-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "afc5508759c5bf4285e61feb862b6083c8480aec864fa17a81fdec6f69b461ab"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-"checksum wincolor 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b9dc3aa9dcda98b5a16150c54619c1ead22e3d3a5d458778ae914be760aa981a"
+"checksum wincolor 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "561ed901ae465d6185fa7864d63fbd5720d0ef718366c9a4dc83cf6170d7e9ba"
 "checksum xml-rs 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3c1cb601d29fe2c2ac60a2b2e5e293994d87a1f6fa9687a31a15270f909be9c2"
-"checksum yaml-rust 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "57ab38ee1a4a266ed033496cf9af1828d8d6e6c1cfa5f643a2809effcae4d628"
+"checksum yaml-rust 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "95acf0db5515d07da9965ec0e0ba6cc2d825e2caeb7303b66ca441729801254e"
 "checksum yansi 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d60c3b48c9cdec42fb06b3b84b5b087405e1fa1c644a1af3930e4dfafe93de48"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,8 @@ license = "MIT/Apache-2.0"
 name = "priroda"
 repository = "https://github.com/oli-obk/priroda"
 version = "0.1.0"
+edition = "2018"
+
 
 [dependencies]
 regex = "1.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -234,7 +234,8 @@ fn server(sender: PrirodaSender) {
                     println!("open {} in your browser", addr);
                 }
             }
-        })).launch();
+        }))
+        .launch();
 }
 
 // Copied from miri/bin/miri.rs
@@ -318,7 +319,8 @@ fn main() {
                 });
 
                 rustc_driver::run_compiler(&*args, Box::new(control), None, None);
-            }).join();
+            })
+            .join();
             std::thread::sleep(std::time::Duration::from_millis(200));
         }
         println!("\n============== Miri crashed too often. Aborting ==============\n");

--- a/src/render/graphviz.rs
+++ b/src/render/graphviz.rs
@@ -9,11 +9,11 @@
 // except according to those terms.
 
 use miri::Frame;
-use rustc::mir::*;
+use crate::rustc::mir::*;
 use std::fmt::{self, Debug, Write};
-use step::LocalBreakpoints;
+use crate::step::LocalBreakpoints;
 
-use rustc_data_structures::indexed_vec::Idx;
+use crate::rustc_data_structures::indexed_vec::Idx;
 
 pub fn render_html(frame: &Frame, breakpoints: LocalBreakpoints) -> String {
     let mut rendered = String::new();
@@ -24,7 +24,7 @@ pub fn render_html(frame: &Frame, breakpoints: LocalBreakpoints) -> String {
     }
     let (bb, stmt) = {
         let blck = &frame.mir.basic_blocks()[frame.block];
-        use rustc_data_structures::indexed_vec::Idx;
+        use crate::rustc_data_structures::indexed_vec::Idx;
         (
             frame.block.index() + 1,
             if frame.stmt == blck.statements.len() {
@@ -42,7 +42,7 @@ pub fn render_html(frame: &Frame, breakpoints: LocalBreakpoints) -> String {
     let edge_colors = {
         let blck = &frame.mir.basic_blocks()[frame.block];
         let (targets, unwind) = if frame.stmt == blck.statements.len() {
-            use rustc::mir::TerminatorKind::*;
+            use crate::rustc::mir::TerminatorKind::*;
             match blck.terminator().kind {
                 Goto { target } => (vec![target], None),
                 SwitchInt { ref targets, .. } => (targets.to_vec(), None),
@@ -185,7 +185,7 @@ fn write_node_label<W: Write>(
             } else {
                 write!(w, "&nbsp; ")?;
             }
-            if ::should_hide_stmt(statement) {
+            if crate::should_hide_stmt(statement) {
                 write!(w, "&lt;+&gt;<br/>")?;
             } else {
                 write!(w, "{}<br/>", escape(statement))?;

--- a/src/render/graphviz.rs
+++ b/src/render/graphviz.rs
@@ -74,12 +74,14 @@ pub fn render_html(frame: &Frame, breakpoints: LocalBreakpoints) -> String {
                     unwind
                         .into_iter()
                         .map(|target| (frame.block, target, "red"))
-                ).map(|(from, to, color)| format!(
+                )
+                .map(|(from, to, color)| format!(
                     "'bb{}->bb{}':'{}'",
                     from.index(),
                     to.index(),
                     color
-                )).collect::<Vec<_>>()
+                ))
+                .collect::<Vec<_>>()
                 .join(",")
         )
     };
@@ -113,7 +115,8 @@ pub fn render_html(frame: &Frame, breakpoints: LocalBreakpoints) -> String {
             bb,
             stmt,
             edge_colors = edge_colors
-        )).unwrap();
+        ))
+        .unwrap();
     rendered
 }
 

--- a/src/render/graphviz.rs
+++ b/src/render/graphviz.rs
@@ -8,12 +8,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use miri::Frame;
 use crate::rustc::mir::*;
-use std::fmt::{self, Debug, Write};
 use crate::step::LocalBreakpoints;
-
-use crate::rustc_data_structures::indexed_vec::Idx;
+use miri::Frame;
+use std::fmt::{self, Debug, Write};
 
 pub fn render_html(frame: &Frame, breakpoints: LocalBreakpoints) -> String {
     let mut rendered = String::new();
@@ -24,7 +22,6 @@ pub fn render_html(frame: &Frame, breakpoints: LocalBreakpoints) -> String {
     }
     let (bb, stmt) = {
         let blck = &frame.mir.basic_blocks()[frame.block];
-        use crate::rustc_data_structures::indexed_vec::Idx;
         (
             frame.block.index() + 1,
             if frame.stmt == blck.statements.len() {

--- a/src/render/locals.rs
+++ b/src/render/locals.rs
@@ -59,7 +59,8 @@ pub fn render_locals<'a, 'tcx: 'a>(
                 None => (None, "&lt;uninit&gt;".to_owned(), "font-size: 0;"),
             };
             (name, ty.to_string(), alloc, val, style)
-        }).collect();
+        })
+        .collect();
 
     let (arg_count, var_count, tmp_count) = (
         mir.args_iter().count(),
@@ -146,11 +147,10 @@ fn pp_value<'a, 'tcx: 'a>(
                 if let Ok(allocation) = ecx.memory.get(ptr.alloc_id) {
                     let offset = ptr.offset.bytes();
                     if (offset as u128) < allocation.bytes.len() as u128 {
-                        let alloc_bytes =
-                            &allocation.bytes[offset as usize
-                                                  ..(offset as usize)
-                                                      .checked_add(len as usize)
-                                                      .ok_or(EvalErrorKind::AssumptionNotHeld)?];
+                        let alloc_bytes = &allocation.bytes[offset as usize
+                            ..(offset as usize)
+                                .checked_add(len as usize)
+                                .ok_or(EvalErrorKind::AssumptionNotHeld)?];
                         let s = String::from_utf8_lossy(alloc_bytes);
                         return Ok(format!("\"{}\"", s));
                     }

--- a/src/render/locals.rs
+++ b/src/render/locals.rs
@@ -1,11 +1,13 @@
 use crate::rustc::mir::{self, interpret::EvalErrorKind};
 use crate::rustc::ty::{
-    layout::{Abi, LayoutOf, Size},
-    Ty, TyS, TypeAndMut, TypeVariants,
+    layout::{Abi, Size},
+    ParamEnv, TyKind, TyS, TypeAndMut,
 };
-use crate::rustc_data_structures::indexed_vec::Idx;
 
-use miri::{Allocation, EvalResult, Frame, Place, PlaceExtra, Pointer, Scalar, ValTy, Value};
+use miri::{
+    Allocation, EvalResult, Frame, LocalValue, OpTy, Operand, Place, Pointer, PointerArithmetic,
+    Scalar, ScalarMaybeUndef, Value,
+};
 
 use horrorshow::prelude::*;
 use horrorshow::Template;
@@ -25,38 +27,43 @@ pub fn render_locals<'a, 'tcx: 'a>(
     } = frame;
 
     //               name    ty      alloc        val     style
-    let locals: Vec<(String, String, Option<u64>, String, &str)> = locals
-        .iter()
-        .enumerate()
-        .map(|(id, &val)| {
-            let mut val = val;
-            let local_decl = &mir.local_decls[mir::Local::new(id)];
+    let locals: Vec<(String, String, Option<u64>, String, &str)> = mir
+        .local_decls
+        .iter_enumerated()
+        .map(|(id, local_decl)| {
             let name = local_decl
                 .name
                 .map(|n| n.as_str().to_string())
                 .unwrap_or_else(String::new);
             let ty = ecx.monomorphize(local_decl.ty, instance.substs);
-            if id == 0 {
-                val = match *return_place {
-                    Place::Ptr { ptr, align, extra } => {
-                        if extra != PlaceExtra::None {
-                            return (
-                                name,
-                                ty.to_string(),
-                                None,
-                                "&lt;unsupported&gt;".to_owned(),
-                                "color: red;",
-                            );
+
+            let op_ty = if id == mir::RETURN_PLACE {
+                return_place.map(|p| {
+                    ecx.place_to_op(p).unwrap()
+                })
+            } else {
+                match *locals.get(id).unwrap() /* never None, because locals has a entry for every defined local */ {
+                    LocalValue::Dead => None,
+                    LocalValue::Live(op) => {
+                        if ecx.frame() as *const _ == frame as *const _ {
+                            Some(ecx.eval_operand(&mir::Operand::Move(mir::Place::Local(id)), None).unwrap())
+
+                        } else {
+                            None // TODO Above doesn't work for non top frames
                         }
-                        Some(Value::ByRef(ptr, align))
+                        //Some(OpTy { op, layout: ecx.tcx.layout_of(ParamEnv::reveal_all().and(ty)).unwrap() })
                     }
-                    Place::Local { frame, local } => ecx.stack()[frame].get_local(local).ok(),
-                };
-            }
-            let (alloc, val, style) = match val.map(|value| print_value(ecx, ty, value)) {
-                Some(Ok((alloc, text))) => (alloc, text, ""),
-                Some(Err(())) => (None, "&lt;error&gt;".to_owned(), "color: red;"),
+                }
+            };
+
+            let (alloc, val, style) = match op_ty {
                 None => (None, "&lt;uninit&gt;".to_owned(), "font-size: 0;"),
+                Some(op_ty) => {
+                    match print_operand(ecx, op_ty) {
+                        Ok((alloc, text)) => (alloc, text, ""),
+                        Err(()) => (None, "&lt;error&gt;".to_owned(), "color: red;"),
+                    }
+                }
             };
             (name, ty.to_string(), alloc, val, style)
         })
@@ -105,70 +112,77 @@ pub fn render_locals<'a, 'tcx: 'a>(
         .unwrap()
 }
 
-fn print_primval(val: Scalar) -> String {
+fn print_scalar_maybe_undef(val: ScalarMaybeUndef) -> String {
     match val {
-        Scalar::Bits { defined: 0, .. } => "&lt;undef &gt;".to_string(),
+        ScalarMaybeUndef::Undef => "&lt;undef &gt;".to_string(),
+        ScalarMaybeUndef::Scalar(val) => print_scalar(val),
+    }
+}
+
+fn print_scalar(val: Scalar) -> String {
+    match val {
         Scalar::Ptr(ptr) => format!(
             "<a href=\"/ptr/{alloc}/{offset}\">Pointer({alloc})[{offset}]</a>",
             alloc = ptr.alloc_id.0,
             offset = ptr.offset.bytes()
         ),
-        Scalar::Bits { bits, defined } => {
-            format!("0x{:0width$X}", bits, width = (defined as usize) / 8)
+        Scalar::Bits { bits, size } => {
+            if size == 0 {
+                "&lt;zst&gt;".to_string()
+            } else {
+                format!("0x{:0width$X}", bits, width = (size as usize) / 8)
+            }
         }
     }
 }
 
-fn pp_value<'a, 'tcx: 'a>(
+fn pp_operand<'a, 'tcx: 'a>(
     ecx: &EvalContext<'a, 'tcx>,
-    ty: Ty<'tcx>,
-    val: Value,
+    op_ty: OpTy<'tcx>,
 ) -> EvalResult<'tcx, String> {
-    let layout = ecx.layout_of(ty).map_err(|_| {
-        EvalErrorKind::AssumptionNotHeld // Don't pretty print dst's
-    })?;
-    match ty.sty {
-        TypeVariants::TyRawPtr(TypeAndMut {
+    match op_ty.layout.ty.sty {
+        TyKind::RawPtr(TypeAndMut {
             ty: &TyS {
-                sty: TypeVariants::TyStr,
-                ..
+                sty: TyKind::Str, ..
             },
             ..
         })
-        | TypeVariants::TyRef(
+        | TyKind::Ref(
             _,
             &TyS {
-                sty: TypeVariants::TyStr,
-                ..
+                sty: TyKind::Str, ..
             },
             _,
         ) => {
-            if let Value::ScalarPair(Scalar::Ptr(ptr), Scalar::Bits { bits: len, .. }) = val {
-                if let Ok(allocation) = ecx.memory.get(ptr.alloc_id) {
-                    let offset = ptr.offset.bytes();
-                    if (offset as u128) < allocation.bytes.len() as u128 {
-                        let alloc_bytes = &allocation.bytes[offset as usize
-                            ..(offset as usize)
-                                .checked_add(len as usize)
-                                .ok_or(EvalErrorKind::AssumptionNotHeld)?];
-                        let s = String::from_utf8_lossy(alloc_bytes);
-                        return Ok(format!("\"{}\"", s));
+            if let Operand::Immediate(val) = *op_ty {
+                if let Value::ScalarPair(
+                    ScalarMaybeUndef::Scalar(Scalar::Ptr(ptr)),
+                    ScalarMaybeUndef::Scalar(Scalar::Bits { bits: len, .. }),
+                ) = val
+                {
+                    if let Ok(allocation) = ecx.memory.get(ptr.alloc_id) {
+                        let offset = ptr.offset.bytes();
+                        if (offset as u128) < allocation.bytes.len() as u128 {
+                            let alloc_bytes = &allocation.bytes[offset as usize
+                                ..(offset as usize)
+                                    .checked_add(len as usize)
+                                    .ok_or(EvalErrorKind::AssumptionNotHeld)?];
+                            let s = String::from_utf8_lossy(alloc_bytes);
+                            return Ok(format!("\"{}\"", s));
+                        }
                     }
                 }
             }
         }
-        TypeVariants::TyAdt(adt_def, _substs) => {
-            if let Value::Scalar(Scalar::Bits { defined: 0, .. }) = val {
+        TyKind::Adt(adt_def, _substs) => {
+            if let Operand::Immediate(Value::Scalar(ScalarMaybeUndef::Undef)) = *op_ty {
                 Err(EvalErrorKind::AssumptionNotHeld)?;
             }
 
             let variant = if adt_def.variants.len() == 1 {
                 0
-            } else if let Value::ByRef(ptr, align) = val {
-                let ptr = ptr.to_ptr()?;
-                ecx.read_discriminant_as_variant_index(Place::from_ptr(ptr, align), layout)?
             } else {
-                Err(EvalErrorKind::AssumptionNotHeld)?
+                ecx.read_discriminant(op_ty)?.1
             };
 
             let adt_fields = &adt_def.variants[variant].fields;
@@ -195,9 +209,8 @@ fn pp_value<'a, 'tcx: 'a>(
 
             for (i, adt_field) in adt_fields.iter().enumerate() {
                 let field_pretty: EvalResult<String> = try {
-                    let (field_val, field_layout) =
-                        ecx.read_field(val, None, crate::rustc::mir::Field::new(i), layout)?;
-                    pp_value(ecx, field_layout.ty, field_val)?
+                    let field_op_ty = ecx.operand_field(op_ty, i as u64)?;
+                    pp_operand(ecx, field_op_ty)?
                 };
 
                 pretty.push_str(&format!(
@@ -224,20 +237,20 @@ fn pp_value<'a, 'tcx: 'a>(
         _ => {}
     }
 
-    if layout.size.bytes() == 0 {
+    if op_ty.layout.size.bytes() == 0 {
         Err(EvalErrorKind::AssumptionNotHeld)?;
     }
-    if let Abi::Scalar(_) = layout.abi {
+    if let Abi::Scalar(_) = op_ty.layout.abi {
     } else {
         Err(EvalErrorKind::AssumptionNotHeld)?;
     }
-    let scalar = ecx.value_to_scalar(ValTy { value: val, ty })?;
-    if let Scalar::Ptr(_) = &scalar {
-        return Ok(print_primval(scalar)); // If the value is a ptr, print it
+    let scalar = ecx.read_scalar(op_ty)?;
+    if let ScalarMaybeUndef::Scalar(Scalar::Ptr(_)) = &scalar {
+        return Ok(print_scalar_maybe_undef(scalar)); // If the value is a ptr, print it
     }
-    let bits = scalar.to_bits(layout.size)?;
-    match ty.sty {
-        TypeVariants::TyBool => {
+    let bits = scalar.to_bits(op_ty.layout.size)?;
+    match op_ty.layout.ty.sty {
+        TyKind::Bool => {
             if bits == 0 {
                 Ok("false".to_string())
             } else if bits == 1 {
@@ -246,7 +259,7 @@ fn pp_value<'a, 'tcx: 'a>(
                 Err(EvalErrorKind::AssumptionNotHeld.into())
             }
         }
-        TypeVariants::TyChar if bits < ::std::char::MAX as u128 => {
+        TyKind::Char if bits < ::std::char::MAX as u128 => {
             let chr = ::std::char::from_u32(bits as u32).unwrap();
             if chr.is_ascii() {
                 Ok(format!("'{}'", chr))
@@ -254,12 +267,12 @@ fn pp_value<'a, 'tcx: 'a>(
                 Err(EvalErrorKind::AssumptionNotHeld.into())
             }
         }
-        TypeVariants::TyUint(_) => Ok(format!("{0}", bits)),
-        TypeVariants::TyInt(_) => Ok(format!(
+        TyKind::Uint(_) => Ok(format!("{0}", bits)),
+        TyKind::Int(_) => Ok(format!(
             "{0}",
-            ::miri::sign_extend(ecx.tcx.tcx, bits, ty).unwrap() as i128
+            ::miri::sign_extend(bits, op_ty.layout.size) as i128
         )),
-        TypeVariants::TyFloat(float_ty) => {
+        TyKind::Float(float_ty) => {
             use crate::syntax::ast::FloatTy::*;
             match float_ty {
                 F32 if bits < ::std::u32::MAX as u128 => {
@@ -275,23 +288,31 @@ fn pp_value<'a, 'tcx: 'a>(
     }
 }
 
-pub fn print_value<'a, 'tcx: 'a>(
+pub fn print_operand<'a, 'tcx: 'a>(
     ecx: &EvalContext<'a, 'tcx>,
-    ty: Ty<'tcx>,
-    val: Value,
+    op_ty: OpTy<'tcx>,
 ) -> Result<(Option<u64>, String), ()> {
-    let pretty = pp_value(ecx, ty, val);
+    let pretty = pp_operand(ecx, op_ty);
 
-    let (alloc, txt) = match val {
-        Value::ByRef(ptr, _align) => {
-            let size: Option<u64> = ecx.layout_of(ty).ok().map(|l| l.size.bytes());
-            let (alloc, txt, _len) = print_ptr(ecx, ptr, size)?;
-            (alloc, txt)
+    let (alloc, txt) = match *op_ty {
+        Operand::Indirect(place) => {
+            let size: u64 = op_ty.layout.size.bytes();
+            if place.meta.is_none() {
+                let ptr = place.to_scalar_ptr_align().0;
+                let (alloc, txt, _len) = print_ptr(ecx, ptr, Some(size))?;
+                (alloc, txt)
+            } else {
+                (None, format!("{:?}", place)) // FIXME better printing for unsized locals
+            }
         }
-        Value::Scalar(primval) => (None, print_primval(primval)),
-        Value::ScalarPair(val, extra) => (
+        Operand::Immediate(Value::Scalar(scalar)) => (None, print_scalar_maybe_undef(scalar)),
+        Operand::Immediate(Value::ScalarPair(val, extra)) => (
             None,
-            format!("{}, {}", print_primval(val), print_primval(extra)),
+            format!(
+                "{}, {}",
+                print_scalar_maybe_undef(val),
+                print_scalar_maybe_undef(extra)
+            ),
         ),
     };
     let txt = if let Ok(pretty) = pretty {
@@ -330,7 +351,7 @@ pub fn print_alloc(ptr_size: u64, ptr: Pointer, alloc: &Allocation, size: Option
     let mut s = String::new();
     let mut i = ptr.offset.bytes();
     while i < end {
-        if let Some(&reloc) = alloc.relocations.get(&Size::from_bytes(i)) {
+        if let Some((_tag, reloc)) = alloc.relocations.get(&Size::from_bytes(i)) {
             i += ptr_size;
             write!(&mut s,
                 "<a style=\"text-decoration: none\" href=\"/ptr/{alloc}/{offset}\">┠{nil:─<wdt$}┨</a>",
@@ -343,6 +364,7 @@ pub fn print_alloc(ptr_size: u64, ptr: Pointer, alloc: &Allocation, size: Option
             if alloc
                 .undef_mask
                 .is_range_defined(Size::from_bytes(i), Size::from_bytes(i + 1))
+                .is_ok()
             {
                 write!(&mut s, "{:02x}", alloc.bytes[i as usize] as usize).unwrap();
             } else {

--- a/src/render/locals.rs
+++ b/src/render/locals.rs
@@ -1,16 +1,16 @@
-use rustc::mir::{self, interpret::EvalErrorKind};
-use rustc::ty::{
+use crate::rustc::mir::{self, interpret::EvalErrorKind};
+use crate::rustc::ty::{
     layout::{Abi, LayoutOf, Size},
     Ty, TyS, TypeAndMut, TypeVariants,
 };
-use rustc_data_structures::indexed_vec::Idx;
+use crate::rustc_data_structures::indexed_vec::Idx;
 
 use miri::{Allocation, EvalResult, Frame, Place, PlaceExtra, Pointer, Scalar, ValTy, Value};
 
 use horrorshow::prelude::*;
 use horrorshow::Template;
 
-use EvalContext;
+use crate::EvalContext;
 
 pub fn render_locals<'a, 'tcx: 'a>(
     ecx: &EvalContext<'a, 'tcx>,
@@ -194,9 +194,9 @@ fn pp_value<'a, 'tcx: 'a>(
             }
 
             for (i, adt_field) in adt_fields.iter().enumerate() {
-                let field_pretty: EvalResult<String> = do catch {
+                let field_pretty: EvalResult<String> = try {
                     let (field_val, field_layout) =
-                        ecx.read_field(val, None, ::rustc::mir::Field::new(i), layout)?;
+                        ecx.read_field(val, None, crate::rustc::mir::Field::new(i), layout)?;
                     pp_value(ecx, field_layout.ty, field_val)?
                 };
 
@@ -260,7 +260,7 @@ fn pp_value<'a, 'tcx: 'a>(
             ::miri::sign_extend(ecx.tcx.tcx, bits, ty).unwrap() as i128
         )),
         TypeVariants::TyFloat(float_ty) => {
-            use syntax::ast::FloatTy::*;
+            use crate::syntax::ast::FloatTy::*;
             match float_ty {
                 F32 if bits < ::std::u32::MAX as u128 => {
                     Ok(format!("{}", <f32>::from_bits(bits as u32)))

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -2,16 +2,16 @@ mod graphviz;
 pub mod locals;
 mod source;
 
-use rustc::hir::map::definitions::DefPathData;
-use rustc::ty::layout::Size;
+use crate::rustc::hir::map::definitions::DefPathData;
+use crate::rustc::ty::layout::Size;
 
 use horrorshow::{Raw, Template};
 use rocket::response::content::Html;
 
 use miri::{AllocId, Frame, Pointer};
 
-use step::Breakpoint;
-use PrirodaContext;
+use crate::step::Breakpoint;
+use crate::PrirodaContext;
 
 pub fn template(pcx: &PrirodaContext, title: String, t: impl Template) -> Html<String> {
     let mut buf = String::new();
@@ -100,7 +100,7 @@ pub fn render_main_window(
         .iter()
         .map(|&Breakpoint(def_id, bb, stmt)| format!("{:?}@{}:{}", def_id, bb.index(), stmt))
         .collect();
-    use rustc_data_structures::indexed_vec::Idx;
+    use crate::rustc_data_structures::indexed_vec::Idx;
     let rendered_locals = frame
         .map(|frame| locals::render_locals(&pcx.ecx, frame))
         .unwrap_or_else(String::new);
@@ -247,7 +247,7 @@ pub fn render_ptr_memory(pcx: &PrirodaContext, alloc_id: AllocId, offset: u64) -
 
 pub mod routes {
     use super::*;
-    use *;
+    use crate::*;
 
     pub fn routes() -> Vec<::rocket::Route> {
         routes![index, frame, frame_invalid, ptr, reverse_ptr]

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -89,7 +89,7 @@ pub fn render_main_window(
                 } else {
                     instance.to_string()
                 },
-                pcx.ecx.tcx.sess.codemap().span_to_string(span),
+                pcx.ecx.tcx.sess.source_map().span_to_string(span),
                 format!("{:?}", instance.def_id()),
             )
         })
@@ -100,7 +100,6 @@ pub fn render_main_window(
         .iter()
         .map(|&Breakpoint(def_id, bb, stmt)| format!("{:?}@{}:{}", def_id, bb.index(), stmt))
         .collect();
-    use crate::rustc_data_structures::indexed_vec::Idx;
     let rendered_locals = frame
         .map(|frame| locals::render_locals(&pcx.ecx, frame))
         .unwrap_or_else(String::new);
@@ -184,6 +183,8 @@ pub fn render_main_window(
     )
 }
 
+// TODO Memory::allocations doesn't exist anymore
+/*
 pub fn render_reverse_ptr(pcx: &PrirodaContext, alloc_id: u64) -> Html<String> {
     let allocs: Vec<_> = pcx
         .ecx
@@ -208,6 +209,7 @@ pub fn render_reverse_ptr(pcx: &PrirodaContext, alloc_id: u64) -> Html<String> {
         },
     )
 }
+*/
 
 pub fn render_ptr_memory(pcx: &PrirodaContext, alloc_id: AllocId, offset: u64) -> Html<String> {
     use horrorshow::Raw;
@@ -216,6 +218,7 @@ pub fn render_ptr_memory(pcx: &PrirodaContext, alloc_id: AllocId, offset: u64) -
         Pointer {
             alloc_id,
             offset: Size::from_bytes(offset),
+            tag: (),
         }
         .into(),
         None,
@@ -250,7 +253,7 @@ pub mod routes {
     use crate::*;
 
     pub fn routes() -> Vec<::rocket::Route> {
-        routes![index, frame, frame_invalid, ptr, reverse_ptr]
+        routes![index, frame, frame_invalid, ptr /*, reverse_ptr*/]
     }
 
     view_route!(index: "/", |pcx, flash: Option<rocket::request::FlashMessage>| {
@@ -275,7 +278,10 @@ pub mod routes {
         render::render_ptr_memory(pcx, AllocId(alloc_id), offset)
     });
 
+    // TODO Memory::allocations doesn't exist anymore
+    /*
     view_route!(reverse_ptr: "/reverse_ptr/<ptr>", |pcx, ptr: u64| {
         render::render_reverse_ptr(pcx, ptr)
     });
+    */
 }

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -30,7 +30,8 @@ pub fn template(pcx: &PrirodaContext, title: String, t: impl Template) -> Html<S
                 : t
             }
         }
-    }).write_to_string(&mut buf)
+    })
+    .write_to_string(&mut buf)
     .unwrap();
     Html(buf)
 }
@@ -91,7 +92,8 @@ pub fn render_main_window(
                 pcx.ecx.tcx.sess.codemap().span_to_string(span),
                 format!("{:?}", instance.def_id()),
             )
-        }).collect();
+        })
+        .collect();
     let rendered_breakpoints: Vec<String> = pcx
         .config
         .bptree
@@ -193,7 +195,8 @@ pub fn render_reverse_ptr(pcx: &PrirodaContext, alloc_id: u64) -> Html<String> {
                 .values()
                 .find(|reloc| reloc.0 == alloc_id)
                 .map(|_| id)
-        }).collect();
+        })
+        .collect();
     template(
         pcx,
         format!("Allocations with pointers to Allocation {}", alloc_id),
@@ -213,7 +216,8 @@ pub fn render_ptr_memory(pcx: &PrirodaContext, alloc_id: AllocId, offset: u64) -
         Pointer {
             alloc_id,
             offset: Size::from_bytes(offset),
-        }.into(),
+        }
+        .into(),
         None,
     ) {
         if bytes * 2 > offset {

--- a/src/render/source.rs
+++ b/src/render/source.rs
@@ -2,8 +2,8 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 
 use miri::Frame;
-use rustc::ty::TyCtxt;
-use syntax::codemap::Span;
+use crate::rustc::ty::TyCtxt;
+use crate::syntax::codemap::Span;
 
 use horrorshow::prelude::*;
 use syntect::easy::HighlightLines;

--- a/src/render/source.rs
+++ b/src/render/source.rs
@@ -128,7 +128,8 @@ pub fn render_source(tcx: TyCtxt, frame: Option<&Frame>) -> Box<RenderBox + Send
                         })
                         .rent(|highlighted| (format!("{:?}", sp), mark_span(highlighted, lo, hi)))
                 })
-            }).collect::<Vec<_>>();
+            })
+            .collect::<Vec<_>>();
 
         highlighted_sources
     });

--- a/src/render/source.rs
+++ b/src/render/source.rs
@@ -1,9 +1,9 @@
 use std::cell::RefCell;
 use std::collections::HashMap;
 
-use miri::Frame;
 use crate::rustc::ty::TyCtxt;
-use crate::syntax::codemap::Span;
+use crate::syntax::source_map::Span;
+use miri::Frame;
 
 use horrorshow::prelude::*;
 use syntect::easy::HighlightLines;
@@ -160,10 +160,10 @@ fn get_highlighter<T>(f: impl FnOnce(HighlightLines) -> T) -> (Color, T) {
 }
 
 fn get_file_source_for_span(tcx: TyCtxt, sp: Span) -> Result<(String, usize, usize), String> {
-    let codemap = tcx.sess.codemap();
-    let _ = codemap.span_to_snippet(sp); // Ensure file src is loaded
+    let source_map = tcx.sess.source_map();
+    let _ = source_map.span_to_snippet(sp); // Ensure file src is loaded
 
-    let src = if let Ok(file_lines) = codemap.span_to_lines(sp) {
+    let src = if let Ok(file_lines) = source_map.span_to_lines(sp) {
         if let Some(ref src) = file_lines.file.src {
             src.to_string()
         } else if let Some(src) = file_lines.file.external_src.borrow().get_source() {
@@ -174,8 +174,8 @@ fn get_file_source_for_span(tcx: TyCtxt, sp: Span) -> Result<(String, usize, usi
     } else {
         return Err("<couldnt get lines for span>".to_string());
     };
-    let lo = codemap.bytepos_to_file_charpos(sp.lo()).0;
-    let hi = codemap.bytepos_to_file_charpos(sp.hi()).0;
+    let lo = source_map.bytepos_to_file_charpos(sp.lo()).0;
+    let hi = source_map.bytepos_to_file_charpos(sp.hi()).0;
     Ok((src, lo, hi))
 }
 

--- a/src/step.rs
+++ b/src/step.rs
@@ -1,12 +1,12 @@
-use rustc::hir::def_id::{CrateNum, DefId, DefIndex, DefIndexAddressSpace};
-use rustc::mir;
-use rustc_data_structures::indexed_vec::Idx;
+use crate::rustc::hir::def_id::{CrateNum, DefId, DefIndex, DefIndexAddressSpace};
+use crate::rustc::mir;
+use crate::rustc_data_structures::indexed_vec::Idx;
 use std::collections::{HashMap, HashSet};
 use std::iter::Iterator;
 
 use serde::de::{Deserialize, Deserializer, Error as SerdeError};
 
-use {EvalContext, PrirodaContext};
+use crate::{EvalContext, PrirodaContext};
 
 pub enum ShouldContinue {
     Continue,
@@ -97,12 +97,12 @@ where
         match pcx.ecx.step() {
             Ok(true) => {
                 *pcx.step_count += 1;
-                ::watch::step_callback(pcx);
+                crate::watch::step_callback(pcx);
 
                 if let Some(frame) = pcx.ecx.stack().last() {
                     let blck = &frame.mir.basic_blocks()[frame.block];
                     if frame.stmt != blck.statements.len()
-                        && ::should_hide_stmt(&blck.statements[frame.stmt])
+                        && crate::should_hide_stmt(&blck.statements[frame.stmt])
                         && !pcx.config.bptree.is_at_breakpoint(&pcx.ecx)
                     {
                         continue;
@@ -133,7 +133,7 @@ pub fn is_ret(ecx: &EvalContext) -> bool {
         let basic_block = &stack.mir.basic_blocks()[stack.block];
 
         match basic_block.terminator().kind {
-            ::rustc::mir::TerminatorKind::Return => stack.stmt >= basic_block.statements.len(),
+            crate::rustc::mir::TerminatorKind::Return => stack.stmt >= basic_block.statements.len(),
             _ => false,
         }
     } else {
@@ -204,7 +204,7 @@ fn parse_def_id(s: &str) -> Result<DefId, String> {
 
 pub mod step_routes {
     use super::*;
-    use action_route;
+    use crate::action_route;
 
     pub fn routes() -> Vec<::rocket::Route> {
         routes![restart, single, single_back, next, return_, continue_]
@@ -227,7 +227,7 @@ pub mod step_routes {
             *pcx.step_count -= 1;
             for _ in 0..*pcx.step_count {
                 match pcx.ecx.step() {
-                    Ok(true) => ::watch::step_callback(pcx), // Rebuild traces till the current instruction
+                    Ok(true) => crate::watch::step_callback(pcx), // Rebuild traces till the current instruction
                     res => return format!("Miri is not deterministic causing error {:?}", res),
                 }
             }
@@ -268,7 +268,7 @@ pub mod step_routes {
 
 pub mod bp_routes {
     use super::*;
-    use action_route;
+    use crate::action_route;
     use std::path::PathBuf;
 
     pub fn routes() -> Vec<::rocket::Route> {

--- a/src/watch/mod.rs
+++ b/src/watch/mod.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::fmt::Write;
 
-use crate::rustc::mir::interpret::{Allocation, Pointer};
+use crate::rustc::mir::interpret::{Allocation, Pointer, PointerArithmetic};
 use crate::rustc::ty::layout::Size;
 use crate::rustc::ty::Instance;
 
@@ -83,7 +83,7 @@ pub fn step_callback(pcx: &mut PrirodaContext) {
                         relocations: alloc.relocations.clone(),
                         undef_mask: alloc.undef_mask.clone(),
                         align: alloc.align,
-                        runtime_mutability: alloc.runtime_mutability,
+                        mutability: alloc.mutability,
                     }),
                 ));
             } else if let Some(&(_, AllocTracePoint::Deallocated)) = alloc_trace.trace_points.last()

--- a/src/watch/mod.rs
+++ b/src/watch/mod.rs
@@ -1,11 +1,11 @@
 use std::collections::HashMap;
 use std::fmt::Write;
 
-use rustc::mir::interpret::{Allocation, Pointer};
-use rustc::ty::layout::Size;
-use rustc::ty::Instance;
+use crate::rustc::mir::interpret::{Allocation, Pointer};
+use crate::rustc::ty::layout::Size;
+use crate::rustc::ty::Instance;
 
-use *;
+use crate::*;
 
 mod stack_trace;
 
@@ -121,7 +121,7 @@ view_route!(show: "/show", |pcx| {
         for (step_count, trace_point) in &alloc_trace.trace_points {
             let content = match trace_point {
                 AllocTracePoint::Changed(alloc) => {
-                    ::render::locals::print_alloc(
+                    crate::render::locals::print_alloc(
                         pcx.ecx.memory().pointer_size().bytes(),
                         Pointer::new(*alloc_id, Size::from_bytes(0)),
                         alloc,
@@ -146,7 +146,7 @@ view_route!(show: "/show", |pcx| {
 #[get("/continue_and_show")]
 pub fn continue_and_show(sender: State<PrirodaSender>) -> RResult<Html<String>> {
     sender.do_work(move |pcx| {
-        ::step::step(pcx, |_ecx| ::step::ShouldContinue::Continue);
+        crate::step::step(pcx, |_ecx| crate::step::ShouldContinue::Continue);
     })?;
     show(sender)
 }

--- a/src/watch/stack_trace.rs
+++ b/src/watch/stack_trace.rs
@@ -3,9 +3,9 @@ use std::io::{self, Write as IoWrite};
 use std::process::{Command, Stdio};
 
 use miri::ScalarExt;
-use rustc::ty::{Instance, InstanceDef};
+use crate::rustc::ty::{Instance, InstanceDef};
 
-use *;
+use crate::*;
 
 pub(super) fn step_callback(pcx: &mut PrirodaContext) {
     let ecx = &mut pcx.ecx;
@@ -24,7 +24,7 @@ pub(super) fn step_callback(pcx: &mut PrirodaContext) {
         (frame.stmt, blck)
     };
     if stmt == blck.statements.len() {
-        use rustc::mir::TerminatorKind::*;
+        use crate::rustc::mir::TerminatorKind::*;
         if let Call {
             ref func, ref args, ..
         } = blck.terminator().kind
@@ -35,7 +35,7 @@ pub(super) fn step_callback(pcx: &mut PrirodaContext) {
             stack_trace.push((instance,));
             insert_stack_trace(&mut traces.stack_traces_cpu, stack_trace.clone(), 1);
 
-            let _: ::miri::EvalResult = do catch {
+            let _: ::miri::EvalResult = try {
                 let args = args
                     .into_iter()
                     .map(|op| ecx.eval_operand(op))
@@ -65,9 +65,9 @@ pub(super) fn step_callback(pcx: &mut PrirodaContext) {
 
 fn instance_for_call_operand<'a, 'tcx: 'a>(
     ecx: &mut EvalContext<'a, 'tcx>,
-    func: &'tcx ::rustc::mir::Operand,
+    func: &'tcx crate::rustc::mir::Operand,
 ) -> Instance<'tcx> {
-    let res: ::miri::EvalResult<Instance> = do catch {
+    let res: ::miri::EvalResult<Instance> = try {
         let func = ecx.eval_operand(func)?;
 
         match func.ty.sty {
@@ -104,7 +104,7 @@ fn insert_stack_trace<T: Eq>(traces: &mut Vec<(T, u128)>, trace: T, count: u128)
 }
 
 pub(super) fn show(pcx: &PrirodaContext, buf: &mut impl Write) -> io::Result<()> {
-    writeln!(buf, "{}\n", ::render::refresh_script(pcx)).unwrap();
+    writeln!(buf, "{}\n", crate::render::refresh_script(pcx)).unwrap();
     create_flame_graph(
         &pcx.ecx,
         &mut *buf,
@@ -138,7 +138,7 @@ fn create_flame_graph<'a, 'tcx: 'a>(
 ) -> io::Result<()> {
     let mut flame_data = String::new();
     for (stack_trace, count) in traces {
-        let mut last_crate = ::rustc::hir::def_id::LOCAL_CRATE;
+        let mut last_crate = crate::rustc::hir::def_id::LOCAL_CRATE;
         writeln!(
             flame_data,
             "{} {}",

--- a/src/watch/stack_trace.rs
+++ b/src/watch/stack_trace.rs
@@ -160,10 +160,12 @@ fn create_flame_graph<'a, 'tcx: 'a>(
                         last_crate = instance.def_id().krate;
                     }
                     name
-                }).collect::<Vec<_>>()
+                })
+                .collect::<Vec<_>>()
                 .join(";"),
             count
-        ).map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+        )
+        .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
     }
 
     //::std::fs::write(format!("./resources/{}.txt", _file_name), flame_data.as_bytes())?;
@@ -223,7 +225,8 @@ fn print_stack_traces<'a, 'tcx: 'a>(
                 "{nil: <indent$}",
                 nil = "",
                 indent = 4 * (stack_trace.len() - 1)
-            ).replace(" ", "&nbsp;")
+            )
+            .replace(" ", "&nbsp;")
         )?;
     }
     writeln!(buf, "</ul>")?;


### PR DESCRIPTION
Will update when rust-lang/rust#55179 has landed.

I switched to the 2018 edition for `try` blocks.