### PR TITLE
Remove rental

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -728,7 +728,6 @@ dependencies = [
  "open",
  "promising-future",
  "regex",
- "rental",
  "rocket",
  "serde",
  "serde_json",
@@ -844,27 +843,6 @@ name = "regex-syntax"
 version = "0.6.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5eb417147ba9860a96cfe72a0b93bf88fee1744b5636ec99ab20c1aa9376581"
-
-[[package]]
-name = "rental"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8545debe98b2b139fb04cad8618b530e9b07c152d99a5de83c860b877d67847f"
-dependencies = [
- "rental-impl",
- "stable_deref_trait",
-]
-
-[[package]]
-name = "rental-impl"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "475e68978dc5b743f2f40d8e0a8fdc83f1c5e78cbf4b8fa5e74e73beebc340de"
-dependencies = [
- "proc-macro2 1.0.24",
- "quote 1.0.9",
- "syn 1.0.60",
-]
 
 [[package]]
 name = "rocket"
@@ -1000,12 +978,6 @@ name = "smallvec"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
-
-[[package]]
-name = "stable_deref_trait"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "state"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,6 @@ promising-future = "0.2"
 syntect = "4.2"
 horrorshow = "0.8"
 cgraph = { git = "https://github.com/oli-obk/cgraph.git", rev = "b65e460ee323b31dca55b5541141a6b73272e72a" }
-rental = "0.5.5"
 
 # Uncomment to use local checkout of miri
 # [patch."https://github.com/rust-lang/miri.git"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,8 +16,6 @@ extern crate rustc_type_ir;
 
 #[macro_use]
 extern crate rocket;
-#[macro_use]
-extern crate rental;
 
 mod render;
 mod step;


### PR DESCRIPTION
Fixes #30

The approach I've taken here is basically a brute force approach - we reconstruct the `Vec<Style, &str>` from the file contents when we need it. We construct the `Range<usize>` manually rather than using `HighlightRangeIter`, because the API of `HighlightRangeIter` means we need to do a lot manual plumbing outselves.

CC @trishume 

It's worth noting that the file never changes between the times we are rehighlighting - it's only the HTML we need to regenerate, because our only change is adding a `lightcoral` (`#f08080`) background on the currently active text.