### PR TITLE
Add button to jump to the start of main

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -25,6 +25,7 @@ use std::ops::FnOnce;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
+use miri::Evaluator;
 use rustc_driver::Compilation;
 use rustc_hir::def_id::LOCAL_CRATE;
 use rustc_interface::interface;
@@ -49,7 +50,7 @@ fn should_hide_stmt(stmt: &mir::Statement<'_>) -> bool {
     }
 }
 
-type InterpCx<'tcx> = miri::MiriEvalContext<'tcx, 'tcx>;
+type InterpCx<'tcx> = rustc_mir::interpret::InterpCx<'tcx, 'tcx, Evaluator<'tcx, 'tcx>>;
 
 pub struct PrirodaContext<'a, 'tcx: 'a> {
     ecx: InterpCx<'tcx>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -272,9 +272,11 @@ impl rustc_driver::Callbacks for PrirodaCompilerCalls {
                 traces: watch::Traces::new(),
                 config: &mut *config,
             };
-
+            // Whether we reset to the same place where miri crashed
+            let mut reset = false;
             // Step to the position where miri crashed if it crashed
             for _ in 0..*pcx.step_count {
+                reset = true;
                 match pcx.ecx.step() {
                     Ok(true) => {}
                     res => panic!("Miri is not deterministic causing error {:?}", res),
@@ -285,7 +287,7 @@ impl rustc_driver::Callbacks for PrirodaCompilerCalls {
             let receiver = self.receiver.lock().unwrap_or_else(|err| err.into_inner());
 
             // At the very beginning, go to the start of main unless that is disabled
-            if self.skip_to_main {
+            if !reset && self.skip_to_main {
                 let main_id = pcx
                     .ecx
                     .tcx

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -130,7 +130,7 @@ pub fn render_main_window(
                         a(href="/step/single_back") { div(title="Execute previous MIR statement/terminator (restarts and steps till one stmt before the current stmt)") { : "Step back (slow)" } }
                         a(href="/step/continue") { div(title="Run until termination or breakpoint") { : "Continue" } }
                         a(href="/step/restart") { div(title="Abort execution and restart") { : "Restart" } }
-                        a(href="/step/main") { div(title="Continue to the start of `main`") { : "-> Main" } }
+                        a(href="/step/main") { div(title="Continue to the start of `main`") { : "-> `main`" } }
                         a(href="/breakpoints/add_here") { div(title="Add breakpoint at current location") { : "Add breakpoint here"} }
                         a(href="/breakpoints/remove_all") { div(title="Remove all breakpoints") { : "Remove all breakpoints"} }
                     } else {

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -130,7 +130,6 @@ pub fn render_main_window(
                         a(href="/step/single_back") { div(title="Execute previous MIR statement/terminator (restarts and steps till one stmt before the current stmt)") { : "Step back (slow)" } }
                         a(href="/step/continue") { div(title="Run until termination or breakpoint") { : "Continue" } }
                         a(href="/step/restart") { div(title="Abort execution and restart") { : "Restart" } }
-                        a(href="/step/main") { div(title="Continue to the start of `main`") { : "-> `main`" } }
                         a(href="/breakpoints/add_here") { div(title="Add breakpoint at current location") { : "Add breakpoint here"} }
                         a(href="/breakpoints/remove_all") { div(title="Remove all breakpoints") { : "Remove all breakpoints"} }
                     } else {

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -130,6 +130,7 @@ pub fn render_main_window(
                         a(href="/step/single_back") { div(title="Execute previous MIR statement/terminator (restarts and steps till one stmt before the current stmt)") { : "Step back (slow)" } }
                         a(href="/step/continue") { div(title="Run until termination or breakpoint") { : "Continue" } }
                         a(href="/step/restart") { div(title="Abort execution and restart") { : "Restart" } }
+                        a(href="/step/main") { div(title="Continue to the start of `main`") { : "-> Main" } }
                         a(href="/breakpoints/add_here") { div(title="Add breakpoint at current location") { : "Add breakpoint here"} }
                         a(href="/breakpoints/remove_all") { div(title="Remove all breakpoints") { : "Remove all breakpoints"} }
                     } else {

--- a/src/step.rs
+++ b/src/step.rs
@@ -244,20 +244,11 @@ fn parse_def_id(s: &str) -> Result<DefId, String> {
 
 pub mod step_routes {
     use rocket::response;
-    use rustc_hir::def_id::LOCAL_CRATE;
 
     use super::*;
 
     pub fn routes() -> Vec<::rocket::Route> {
-        routes![
-            restart,
-            single,
-            single_back,
-            next,
-            return_,
-            continue_,
-            continue_to_main
-        ]
+        routes![restart, single, single_back, next, return_, continue_]
     }
 
     #[get("/restart")]
@@ -279,27 +270,6 @@ pub mod step_routes {
                 response::Redirect::to("/"),
                 step(pcx, |_ecx| ShouldContinue::Stop),
             )
-        })
-    }
-
-    #[get("/main")]
-    fn continue_to_main(
-        sender: rocket::State<'_, crate::PrirodaSender>,
-    ) -> crate::RResult<response::Flash<response::Redirect>> {
-        sender.do_work(move |pcx| {
-            let main_id = pcx
-                .ecx
-                .tcx
-                .tcx
-                .entry_fn(LOCAL_CRATE)
-                .expect("no main or start function found")
-                .0
-                .to_def_id();
-            pcx.config
-                .bptree
-                .add_breakpoint(Breakpoint(main_id, mir::BasicBlock::new(0), 0));
-            let msg = step(pcx, |_ecx| ShouldContinue::Continue);
-            response::Flash::success(response::Redirect::to("/"), msg)
         })
     }
 


### PR DESCRIPTION
Fixes #29 

At the start, we now move to main automatically, unless `--no-main` is passed.