### PR TITLE
Update to latest rustc and miri

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,8 +10,8 @@ jobs:
       - uses: actions/checkout@v2
       # Toolchain installation should appear as a seperate step for timing purposes
       - run: rustup show
-      # Install graphviz
-      - run: apt install libgraphviz-dev
+      - name: Setup Graphviz
+        uses: ts-graphviz/setup-graphviz@v1
       - uses: actions-rs/cargo@v1
         with:
           command: check

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,8 @@ jobs:
       - uses: actions/checkout@v2
       # Toolchain installation should appear as a seperate step for timing purposes
       - run: rustup show
+      # Install graphviz
+      - run: apt install libgraphviz-dev
       - uses: actions-rs/cargo@v1
         with:
           command: check

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,8 +189,11 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cgraph"
-version = "0.1.0"
-source = "git+https://github.com/oli-obk/cgraph.git?rev=b65e460ee323b31dca55b5541141a6b73272e72a#b65e460ee323b31dca55b5541141a6b73272e72a"
+version = "0.1.1"
+source = "git+https://github.com/oli-obk/cgraph.git?rev=7348380f014fe87338cdcd4d2f22cbda771ae21d#7348380f014fe87338cdcd4d2f22cbda771ae21d"
+dependencies = [
+ "pkg-config",
+]
 
 [[package]]
 name = "chrono"
@@ -560,7 +563,7 @@ dependencies = [
 [[package]]
 name = "miri"
 version = "0.1.0"
-source = "git+https://github.com/rust-lang/miri.git?rev=ea86335318fd06ec964d9a86b187995bda1b6c7d#ea86335318fd06ec964d9a86b187995bda1b6c7d"
+source = "git+https://github.com/rust-lang/miri.git?rev=ae964207bb17911cf96d9744d9469fa2734093a8#ae964207bb17911cf96d9744d9469fa2734093a8"
 dependencies = [
  "env_logger",
  "getrandom 0.2.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ regex = "1.3"
 lazy_static = "1.4.0"
 rocket = "0.4.7"
 # This needs to be the version of miri for the nightly in the `rust-toolchain` file
-miri = { git = "https://github.com/rust-lang/miri.git", rev = "ea86335318fd06ec964d9a86b187995bda1b6c7d" }
+miri = { git = "https://github.com/rust-lang/miri.git", rev = "ae964207bb17911cf96d9744d9469fa2734093a8" }
 
 log = "0.4"
 env_logger = "0.7"
@@ -25,7 +25,7 @@ open = "1.4.0"
 promising-future = "0.2"
 syntect = "4.2"
 horrorshow = "0.8"
-cgraph = { git = "https://github.com/oli-obk/cgraph.git", rev = "b65e460ee323b31dca55b5541141a6b73272e72a" }
+cgraph = { git = "https://github.com/oli-obk/cgraph.git", rev = "7348380f014fe87338cdcd4d2f22cbda771ae21d" }
 
 # Uncomment to use local checkout of miri
 # [patch."https://github.com/rust-lang/miri.git"]

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2021-03-01"
+channel = "nightly-2021-03-13"
 components = ["miri", "rustc-dev", "llvm-tools-preview"]


### PR DESCRIPTION
I'm also considering removing the svg-pan-zoom submodule - we currently don't actually use it at all.