### PR TITLE
Remove heroku hosting

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,0 @@
-web: ./web.sh

--- a/web.sh
+++ b/web.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-export PATH="$HOME/.cargo/bin:$PATH"
-export ROCKET_ENV=production
-export ROCKET_PORT=$PORT
-rustup run nightly target/release/priroda example.rs --sysroot $(rustc +nightly --print sysroot)


### PR DESCRIPTION
As indicated at https://help.heroku.com/RSBRUH58/removal-of-heroku-free-product-plans-faq heroku is going to remove their free plan soon. This means that the instance of Prirode I hosted on heroku at https://bjorn3-priroda-public.herokuapp.com/ will stop working soon. There is little point in leaving the files used for deploying this heroku instance anymore.